### PR TITLE
Dockerise le bot pour le déployer via Komodo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --ignore-scripts
+
+COPY . .
+
+CMD ["node", "Start_Bot_Roles.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  bot:
+    build: .
+    image: rolelist-bot
+    container_name: rolelist-bot
+    restart: unless-stopped
+    volumes:
+      - ./config.json:/app/config.json
+      - ./logs:/app/logs


### PR DESCRIPTION
Closes #21

## Ce qui change

- `Dockerfile` : `node:20-alpine`, `npm install --ignore-scripts` (le
  script `"install": "node setup.js"` dans `package.json` référence un
  fichier inexistant — bug préexistant, contourné ici plutôt que corrigé,
  hors scope de cette PR)
- `docker-compose.yml` : build + run, `config.json` (gitignored, contient
  le token Discord) et `logs/` montés en volume plutôt que dupliqués dans
  l'image

## Après merge

Le conteneur sera géré par Komodo, même pattern que
`UnionRolistes/Web_Site#20`.

## Testé

- [x] Build Docker local : OK
- [x] Démarrage sans `config.json` : échec propre et attendu
  (`Cannot find module './config.json'`), confirme que le code et les
  dépendances chargent correctement